### PR TITLE
Fix tool naming for Claude API compliance

### DIFF
--- a/src/multimcp/mcp_proxy.py
+++ b/src/multimcp/mcp_proxy.py
@@ -305,10 +305,10 @@ class MCPProxyServer(server.Server):
 
     @staticmethod
     def _make_key(server_name: str, item_name: str) -> str:
-        """Returns a namespaced key like 'server::item' to uniquely identify items per server."""
-        return f"{server_name}::{item_name}"
+        """Returns a namespaced key like 'server_item' to uniquely identify items per server."""
+        return f"{server_name}_{item_name}"
 
     @staticmethod
     def _split_key(key: str) -> tuple[str, str]:
         """Splits a namespaced key back into (server, item)."""
-        return key.split("::", 1)
+        return key.split("_", 1)


### PR DESCRIPTION
## Summary

- Replace `::` separator with `_` in tool naming to comply with Claude's function calling API requirements
- Update both `_make_key()` and `_split_key()` methods for consistency
- Enable proper integration between multi-mcp and Claude Code

## Problem

Claude's function calling API enforces strict naming patterns for tools. Tool names must match the regex pattern `^[a-zA-Z0-9_-]{1,128}$` (only alphanumeric characters, underscores, and hyphens are allowed).

The current implementation uses `::` as a separator in the **exposed tool names** (not just internally):
- `weather::get_weather`
- `calculator::add`
- `calculator::multiply`

This causes API validation errors when Claude Code attempts to use these tools.

### How to Reproduce

1. Start multi-mcp with the current implementation:
   ```bash
   uv run main.py --transport sse --log-level DEBUG
   ```

2. Configure Claude Code to connect:
   ```bash
   claude mcp add --transport sse multi-mcp http://127.0.0.1:8080/sse
   ```

3. In Claude Code, try to use a tool:
   ```
   Can you add 5 and 7 using the calculator?
   ```

4. Observe the error:
   ```
   API Error: 400 {"type":"error","error":{"type":"invalid_request_error","message":"tools.16.custom.name: String should match pattern '^[a-zA-Z0-9_-]{1,128}$'"}}
   ```

The error occurs because Claude's API rejects the `calculator::add` tool name due to the `::` characters not matching the required pattern.

## Solution

Updated the tool naming strategy to use `_` instead of `::` for the exposed tool names:
- `weather_get_weather` ✅
- `calculator_add` ✅
- `calculator_multiply` ✅

**Changes made:**
1. `_make_key()`: Changed `f"{server_name}::{item_name}"` → `f"{server_name}_{item_name}"`
2. `_split_key()`: Changed `key.split("::", 1)` → `key.split("_", 1)`
3. Updated docstrings to reflect the new naming pattern

## Technical Details

The multi-mcp proxy aggregates tools from multiple MCP servers and exposes them through a single interface. To prevent naming conflicts (e.g., two servers both having an "add" tool), it namespaces the tools by prefixing them with the server name.

While the README mentions "namespaced internally", the actual implementation exposes these namespaced names directly to clients. The `::` separator works fine for internal tracking but violates Claude's API requirements when these names are passed to the function calling API.

## Test Plan

- [x] Apply the fix to a local multi-mcp installation
- [x] Start multi-mcp server with SSE transport
- [x] Configure Claude Code to connect via `claude mcp add --transport sse`
- [x] Verify tools are accessible and functional in Claude Code session
- [x] Test both weather and calculator tools work correctly

## References

- [Claude Code MCP Documentation](https://docs.anthropic.com/en/docs/claude-code/mcp)
- Related issue: Tool naming compliance preventing Claude Code integration

## Impact

This change enables seamless integration between multi-mcp and Claude Code, allowing users to access aggregated MCP tools through the proxy server without API validation errors.

Commit: 81c89b7

🤖 Generated with [Claude Code](https://claude.ai/code)